### PR TITLE
Update to harmonic-params, s1dc-flood-mapper and advisory-flagging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,9 @@ Changelog
 Version 0.2.5
 =============
 
-- changes of the scale factor handling for harmonic-params (v0.2)
+- updates regarding encoding in harmonic-params (v0.2)
+- updates regarding encoding and thresholds in advisory-flagging (v0.1)
+- updates regarding encoding and post-processing in s1dc-flood-mapper (v0.2)
 
 Version 0.2.4
 =============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 0.2.5
+=============
+
+- changes of the scale factor handling for harmonic-params (v0.2)
+
 Version 0.2.4
 =============
 

--- a/src/medali/lib/advisory_flagging/V01.ini
+++ b/src/medali/lib/advisory_flagging/V01.ini
@@ -1,4 +1,4 @@
-# Advisory flags metadata, version 01
+# Advisory flags metadata, version 0.1
 
 [Metadata]
 

--- a/src/medali/lib/advisory_flagging/V1M0.ini
+++ b/src/medali/lib/advisory_flagging/V1M0.ini
@@ -1,4 +1,4 @@
-# Advisory flags metadata, version 01
+# Advisory flags metadata, version 0.1
 
 [Metadata]
 

--- a/src/medali/lib/advisory_flagging/V1M1.ini
+++ b/src/medali/lib/advisory_flagging/V1M1.ini
@@ -1,0 +1,93 @@
+# Advisory flags metadata, version 01
+
+[Metadata]
+
+# acquisition date - sensing start date
+sensing_date: datetime
+
+# creation date - date of the data processing
+creation_date: datetime
+
+# modification date - date of last modification, by default set the same as the creation time when processing the data
+modification_date: datetime
+
+# acquisition mode id
+mode: string
+
+# relative orbit number
+rel_orbit_number: integer
+
+# orbit direction (ascending or descending)
+orbit_direction: string
+
+# tile id - EQUI7 tile ID
+tile_id: string
+
+# dataset creator
+creator: string
+
+# name of the used worker software
+worker_name: string
+
+# tag of the used worker software
+worker_git_tag: string
+
+# 7-digit commit of the used worker software
+worker_git_commit: string
+
+# name of the used wrapper software
+wrapper_name: string
+
+# tag of the used wrapper software
+wrapper_git_tag: string
+
+# 7-digit commit of the used wrapper software
+wrapper_git_commit: string
+
+# run number
+run_number: string
+
+# shadow mask - filename of the shadow mask used
+shadow_mask: string
+
+# seasonal water mask - filename of the seasonal water mask used
+seasonal_water_mask: string
+
+# urban ghs mask - filename of the urban ghs mask used
+urban_ghs_mask: string
+
+# urban wsf mask - filename of the urban wsf mask used
+urban_wsf_mask: string
+
+# oceam mask - filename of the ocean mask used
+ocean_mask: string
+
+# median file - filename of the median file used
+median_file: string
+
+# perc_file - filename of the percentile file used
+perc_file: string
+
+# rough_water_surface_flag_applied - specifies if the eough water surface flag could be applied or not
+rough_water_surface_flag_applied: boolean
+
+# Standard deviation threshold for defining the wind flag
+wind_n_std: float
+
+# Minimum SIG0 backscatter for the wind flag
+wind_min_sig0: integer
+
+# verbal description how the values were encoded
+encoding_info: string
+
+# verbal description of the values
+value_info: string
+
+[Expected_value]
+
+# acquisition mode id
+mode: list, IW, EW
+
+# orbit direction id
+orbit_direction: list, A, D
+

--- a/src/medali/lib/advisory_flagging/V1M1.ini
+++ b/src/medali/lib/advisory_flagging/V1M1.ini
@@ -65,8 +65,8 @@ ocean_mask: string
 # median file - filename of the median file used
 median_file: string
 
-# perc_file - filename of the percentile file used
-perc_file: string
+# plia file - filename of the plia file used
+plia_file: string
 
 # rough_water_surface_flag_applied - specifies if the eough water surface flag could be applied or not
 rough_water_surface_flag_applied: boolean

--- a/src/medali/lib/advisory_flagging/V1M1.ini
+++ b/src/medali/lib/advisory_flagging/V1M1.ini
@@ -63,7 +63,7 @@ urban_wsf_mask: string
 ocean_mask: string
 
 # median file - filename of the median file used
-median_file: string
+sig0_median_file: string
 
 # plia file - filename of the plia file used
 plia_file: string
@@ -71,7 +71,7 @@ plia_file: string
 # rough_water_surface_flag_applied - specifies if the eough water surface flag could be applied or not
 rough_water_surface_flag_applied: boolean
 
-# Standard deviation threshold for defining the wind flag
+# Multiplier n of the water standard deviation to define wind flag threshold
 wind_n_std: float
 
 # Minimum SIG0 backscatter for the wind flag

--- a/src/medali/lib/advisory_flagging/V1M1.ini
+++ b/src/medali/lib/advisory_flagging/V1M1.ini
@@ -1,4 +1,4 @@
-# Advisory flags metadata, version 01
+# Advisory flags metadata, version 0.2
 
 [Metadata]
 

--- a/src/medali/lib/harmonic_params/V01.ini
+++ b/src/medali/lib/harmonic_params/V01.ini
@@ -1,4 +1,4 @@
-# Harmonic parameters metadata, version 01
+# Harmonic parameters metadata, version 0.1
 
 [Metadata]
 

--- a/src/medali/lib/harmonic_params/V1M0.ini
+++ b/src/medali/lib/harmonic_params/V1M0.ini
@@ -1,4 +1,4 @@
-# Harmonic parameters metadata, version 1.0
+# Harmonic parameters metadata, version 0.2
 
 [Metadata]
 

--- a/src/medali/lib/harmonic_params/V1M1.ini
+++ b/src/medali/lib/harmonic_params/V1M1.ini
@@ -29,8 +29,8 @@ wrapper_git_tag: string
 # 7-digit commit of the used wrapper software
 wrapper_git_commit: string
 
-# input data version version of the input data used for harmonic regression computation (e.g. V01R01)
-input_data_version: string
+# input data version versions of the input data used for harmonic regression computation (e.g. V01R01)
+input_data_version: list
 
 # variable name - name of the variable used for harmonic regression computation ( e.g. sig0, gam0, plia, ...)
 input_variable_name: string
@@ -92,7 +92,7 @@ orbit_direction: list, A, D
 band: list, VH, VV
 
 # variable name id
-variable_name: list, SIG0, GMR0
+variable_name: list, SIG0, GMR
 
 # harmonic parameter id
 harmonic_parameter: list, S1, S2, S3, S4, S5, S6, C1, C2, C3, C4, C5, C6, M0, NOBS, STD

--- a/src/medali/lib/harmonic_params/V1M1.ini
+++ b/src/medali/lib/harmonic_params/V1M1.ini
@@ -1,4 +1,4 @@
-# Harmonic parameters metadata, version 1.0
+# Harmonic parameters metadata, version 0.2
 
 [Metadata]
 

--- a/src/medali/lib/harmonic_params/V1M1.ini
+++ b/src/medali/lib/harmonic_params/V1M1.ini
@@ -74,9 +74,6 @@ redundancy: integer
 # number of obervation available - information if the number of observation layer is available
 num_obs_available: boolean
 
-# data type - data type within the parameter image
-data_type: string
-
 # verbal description how the values were encoded
 encoding_info: string
 

--- a/src/medali/lib/harmonic_params/V1M1.ini
+++ b/src/medali/lib/harmonic_params/V1M1.ini
@@ -1,0 +1,101 @@
+# Harmonic parameters metadata, version 1.0
+
+[Metadata]
+
+# creation date - date of the data processing
+date_creation: datetime
+
+# modification date - date of last modification, by default set the same as the creation time when processing the data
+date_modification: datetime
+
+# dataset creator
+creator: string
+
+# name of the used worker software
+worker_name: string
+
+# tag of the used worker software
+worker_git_tag: string
+
+# 7-digit commit of the used worker software
+worker_git_commit: string
+
+# name of the used wrapper software
+wrapper_name: string
+
+# tag of the used wrapper software
+wrapper_git_tag: string
+
+# 7-digit commit of the used wrapper software
+wrapper_git_commit: string
+
+# input data version version of the input data used for harmonic regression computation (e.g. V01R01)
+input_data_version: string
+
+# variable name - name of the variable used for harmonic regression computation ( e.g. sig0, gam0, plia, ...)
+input_variable_name: string
+
+# input files number - number of input files
+input_files_number: integer
+
+# relative orbit number
+orbit_relative: integer
+
+# orbit direction (ascending or descending)
+orbit_direction: string
+
+# acquisition mode id
+mode: string
+
+# band of the image (e.g. polarisation or name of the respective band)
+band: string
+
+# tile id - EQUI7 tile ID
+tile_id: string
+
+# run number
+run_number: integer
+
+# harmonic parameter - name of the respective harmonic parameter
+harmonic_parameter: string
+
+# start date - starting date of the harmonic regression computation
+start_date: datetime
+
+# end date - end date of the harmonic regression computation
+end_date: datetime
+
+# k value - k value of the harmocnic regression
+k_value: integer
+
+# redundancy of the least-squares adjustment
+redundancy: integer
+
+# number of obervation available - information if the number of observation layer is available
+num_obs_available: boolean
+
+# data type - data type within the parameter image
+data_type: string
+
+# verbal description how the values were encoded
+encoding_info: string
+
+# verbal description of the values
+value_info: string
+
+[Expected_value]
+
+# acquisition mode id
+mode: list, IW, EW
+
+# orbit direction id
+orbit_direction: list, A, D
+
+# band
+band: list, VH, VV
+
+# variable name id
+variable_name: list, SIG0, GMR0
+
+# harmonic parameter id
+harmonic_parameter: list, S1, S2, S3, S4, S5, S6, C1, C2, C3, C4, C5, C6, M0, NOBS, STD

--- a/src/medali/lib/s1dc_flood_mapper/V01.ini
+++ b/src/medali/lib/s1dc_flood_mapper/V01.ini
@@ -1,4 +1,4 @@
-# Flood mapping result metadata, version 01
+# Flood mapping result metadata, version 0.1
 
 [Metadata]
 

--- a/src/medali/lib/s1dc_flood_mapper/V1M0.ini
+++ b/src/medali/lib/s1dc_flood_mapper/V1M0.ini
@@ -1,4 +1,4 @@
-# Flood mapping result metadata, version 1.0
+# Flood mapping result metadata, version 0.2
 
 [Metadata]
 

--- a/src/medali/lib/s1dc_flood_mapper/V1M1.ini
+++ b/src/medali/lib/s1dc_flood_mapper/V1M1.ini
@@ -48,7 +48,7 @@ flood_reference: string
 input_reference: string
 
 # additional detail of the used reference method (e.g. k-value of the harmonic model)
-input_reference_detail: integer
+input_reference_addon: integer
 
 # threshold for the NOBS when using the harmonic model
 reference_nobs_thresh: integer

--- a/src/medali/lib/s1dc_flood_mapper/V1M1.ini
+++ b/src/medali/lib/s1dc_flood_mapper/V1M1.ini
@@ -1,4 +1,4 @@
-# Flood mapping result metadata, version 1.0
+# Flood mapping result metadata, version 0.2
 
 [Metadata]
 

--- a/src/medali/lib/s1dc_flood_mapper/V1M1.ini
+++ b/src/medali/lib/s1dc_flood_mapper/V1M1.ini
@@ -1,0 +1,107 @@
+# Flood mapping result metadata, version 1.0
+
+[Metadata]
+
+# creation date - date of the data processing
+date_creation: datetime
+
+# modification date - date of last modification, by default set the same as the creation time when processing the data
+date_modification: datetime
+
+# acquisition date - sensing start date
+date_sensing: datetime
+
+# dataset creator
+creator: string
+
+# name of the used worker software
+worker_name: string
+
+# tag of the used worker software
+worker_git_tag: string
+
+# 7-digit commit of the used worker software
+worker_git_commit: string
+
+# name of the used wrapper software
+wrapper_name: string
+
+# tag of the used wrapper software
+wrapper_git_tag: string
+
+# 7-digit commit of the used wrapper software
+wrapper_git_commit: string
+
+# selected run number for the processing
+run_number: integer
+
+# filename of Equi7grid tile file
+input_sar_file: string
+
+# name of used plia file (average and single-scene)
+input_plia_file: string
+
+# method used to provide a flood reference (e.g. harmonic, rolling, exponential)
+flood_reference: string
+
+# input for the used flood reference (e.g. M0 harmonic parameter file)
+input_reference: string
+
+# additional detail of the used reference method (e.g. k-value of the harmonic model)
+input_reference_detail: integer
+
+# threshold for the NOBS when using the harmonic model
+reference_nobs_thresh: integer
+
+# slope of mean water backscatter distribution's linear regression
+water_backscatter_slope: float
+
+# intercept of mean water backscatter distribution's linear regression
+water_backscatter_intercept: float
+
+# standard deviation water backscatter distribution's linear regression
+water_backscatter_std: float
+
+# relative orbit number
+orbit_relative: integer
+
+# orbit direction (ascending or descending)
+orbit_direction: string
+
+# Equi7grid tile code
+tile_id: string
+
+# List of applied postprocessing steps
+postprocessing_steps: string
+
+# Overruling option of the post-processign step
+postprocessing_overrule: boolean
+
+# Kernel size used for lee filtering of input scene or zero if no lee filter was applied
+lee_filter_size: integer
+
+# Factor to be multiplied with the water backscatter standard deviation in order to mask conflicting distributions
+distrib_factor: float
+
+# Factor to be multiplied with the standard deviation in order to mask measurement outliers
+outlier_factor: float
+
+# Threshold to mask high uncertainties
+uncert_thresh: float
+
+# a priori probability method (e.g. uninformed, HAND)
+prior_probability: string
+
+# was an additional mask (beside model-based ones) applied on the raw flood map?
+mask_applied: boolean
+
+# verbal description how the values were encoded
+encoding_info: string
+
+# verbal description of the values
+value_info: string
+
+[Expected_value]
+
+# orbit direction id
+orbit_direction: list, A, D


### PR DESCRIPTION
- Added encoding and value info to all three metadata definitions (harmonic-params, s1dc-flood-mapper and advisory-flagging)
- Removed scale factor field from harmonic-params and s1dc-flood-mapper
- Added new fields related to the upcoming version of advisory-flagging
- Removed kernel-size field from s1dc-flood-mapper to prepare new post-processing handling